### PR TITLE
Build Universal2 macOS artifacts in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
 
@@ -33,21 +34,55 @@ jobs:
 
     - name: Install mbedTLS
       run: |
-        curl -sL https://src.fedoraproject.org/repo/pkgs/mbedtls/mbedtls-2.16.12.tar.gz/sha512/8d96d8cd906cc0999134320e4e1f550631426d166eab5da6e65469ee7286093810fcc6ac4bd5500ee55972d159f8bef7f9e53245f7f0eec72f72c35265b4313b/mbedtls-2.16.12.tar.gz | tar xvz -C ./
+        curl -fsSL https://src.fedoraproject.org/repo/pkgs/mbedtls/mbedtls-2.16.12.tar.gz/sha512/8d96d8cd906cc0999134320e4e1f550631426d166eab5da6e65469ee7286093810fcc6ac4bd5500ee55972d159f8bef7f9e53245f7f0eec72f72c35265b4313b/mbedtls-2.16.12.tar.gz | tar xvz -C ./
         cd mbedtls-2.16.12
-        mkdir build && cd build
-        cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-        make mbedcrypto
+        mkdir build
+        # macOS needs Universal2 mbedTLS archives and a macOS 11.0 floor; Linux
+        # keeps the existing native CMake configuration.
+        if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          cmake -S . -B build \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="$(xcrun --find clang)" \
+            -DCMAKE_OSX_SYSROOT="$(xcrun --sdk macosx --show-sdk-path)" \
+            -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+            -DUSE_STATIC_MBEDTLS_LIBRARY=ON \
+            -DUSE_SHARED_MBEDTLS_LIBRARY=OFF \
+            -DENABLE_PROGRAMS=OFF \
+            -DENABLE_TESTING=OFF
+        else
+          cmake -S . -B build -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        fi
+        cmake --build build --target mbedcrypto --parallel
 
     - name: Build Apollo CLI tools
       run: |
         cd tools
-        make clean && make
+        make clean
+        # Make receives the SDK, both architectures, and deployment target via CC
+        # so the CLI matches the CMake-built Universal2 components.
+        if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          make CC="$(xcrun --find clang) -isysroot $(xcrun --sdk macosx --show-sdk-path) -arch x86_64 -arch arm64 -mmacosx-version-min=11.0"
+        else
+          make
+        fi
 
     - name: Build Apollo Patcher GUI
       run: |
         cd gui
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        # Keep the GUI's CMake configuration aligned with Universal2 mbedTLS and
+        # the same macOS 11.0 deployment baseline.
+        if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="$(xcrun --find clang)" \
+            -DCMAKE_CXX_COMPILER="$(xcrun --find clang++)" \
+            -DCMAKE_OSX_SYSROOT="$(xcrun --sdk macosx --show-sdk-path)" \
+            -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
+        else
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        fi
         cmake --build build -j
         # Normalise the output path across OSes for the upload step.
         mkdir -p dist
@@ -56,6 +91,56 @@ jobs:
         else
           cp build/apollo_patcher_gui dist/
         fi
+
+    # Neither gui/CMakeLists.txt nor tools/Makefile sets a deployment target. Use
+    # macOS 11.0, the first Apple Silicon release, as one baseline for both slices.
+    # Fail before upload if a shipped executable or link input loses a CPU slice,
+    # or if a distributable executable raises that baseline.
+    - name: Verify macOS Universal2 and deployment targets
+      if: matrix.os == 'macos-latest'
+      run: |
+        chmod 755 tools/patcher tools/dumper gui/dist/apollo_patcher_gui.app/Contents/MacOS/apollo_patcher_gui
+
+        verify_universal() {
+          local file="$1"
+          test -f "$file"
+          lipo "$file" -verify_arch x86_64 arm64
+          lipo "$file" -info
+        }
+
+        assert_minos_11() {
+          local file="$1"
+          local arch
+          for arch in x86_64 arm64; do
+            # Modern and legacy Mach-O load commands use different fields for
+            # the minimum macOS version.
+            if ! otool -arch "$arch" -l "$file" | awk '
+              $1 == "cmd" && $2 == "LC_BUILD_VERSION" { build=1; legacy=0; next }
+              $1 == "cmd" && $2 == "LC_VERSION_MIN_MACOSX" { legacy=1; build=0; next }
+              $1 == "Load" && $2 == "command" { build=0; legacy=0 }
+              build && $1 == "minos" && $2 == "11.0" { found=1 }
+              legacy && $1 == "version" && $2 == "11.0" { found=1 }
+              END { exit(found ? 0 : 1) }
+            '; then
+              echo "${file} ${arch} does not declare macOS minimum 11.0"
+              otool -arch "$arch" -l "$file"
+              exit 1
+            fi
+          done
+        }
+
+        # Keep this inventory in sync when macOS artifacts or link inputs change.
+        # New shipped executables also need an assert_minos_11 check below.
+        verify_universal mbedtls-2.16.12/build/library/libmbedcrypto.a
+        verify_universal tools/patcher
+        verify_universal tools/dumper
+        verify_universal gui/dist/apollo_patcher_gui.app/Contents/MacOS/apollo_patcher_gui
+        verify_universal gui/build/libapollo_engine.a
+        verify_universal gui/build/libimgui.a
+        verify_universal gui/build/_deps/glfw-build/src/libglfw3.a
+        assert_minos_11 tools/patcher
+        assert_minos_11 tools/dumper
+        assert_minos_11 gui/dist/apollo_patcher_gui.app/Contents/MacOS/apollo_patcher_gui
 
     - name: Get short SHA
       run: echo "sha_name=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_ENV
@@ -66,9 +151,10 @@ jobs:
         path: |
           tools/patcher
           tools/dumper
-          tools/patcher-bigendian
+        if-no-files-found: error
 
     - uses: actions/upload-artifact@v4
       with:
         name: apollo-gui-${{ env.sha_name }}-${{matrix.os}}
         path: gui/dist
+        if-no-files-found: error


### PR DESCRIPTION
# Build Universal2 macOS artifacts in CI

## Summary

The macOS job currently builds artifacts for the runner's native architecture. This updates the workflow so the uploaded Apollo CLI tools and GUI app are built for both Intel and Apple Silicon Macs.

The change stays entirely within the GitHub Actions workflow. No Apollo source, Makefile, or GUI CMake source changes are required.

## What changed

### Universal2 macOS builds

- Resolve Apple `clang`, `clang++`, and the active macOS SDK through `xcrun`.
- Build static mbedTLS `libmbedcrypto.a` in Release mode for `x86_64;arm64`.
- Build `patcher` and `dumper` with both architecture flags and the active SDK.
- Configure the GUI, Apollo engine, GLFW, and Dear ImGui with the same architecture and SDK settings.
- Neither `gui/CMakeLists.txt` nor `tools/Makefile` sets a macOS deployment target, so use macOS 11.0, the first Apple Silicon release, as one baseline for both slices.
- Keep the Ubuntu job on its normal compiler path without passing any macOS-specific flags.

### Artifact verification

- Add a macOS-only validation step before artifacts are uploaded.
- Require both `x86_64` and `arm64` slices in the CLI tools, GUI executable, mbedTLS, Apollo engine, GLFW, and Dear ImGui.
- Check both executable slices with `otool` and require a macOS 11.0 deployment target.
- Set uploaded macOS CLI and GUI executables to mode `755`.

### Workflow cleanup

- Leave the existing unfiltered `push`, `pull_request`, and `repository_dispatch: run_build` trigger behavior unchanged.
- Add concise comments around the platform split and macOS verification so the reason for the Universal2-specific configuration is clear.
- Set `fail-fast: false` so a failure on one matrix platform does not cancel the other platform's result.
- Use `curl -fsSL` so HTTP failures stop the mbedTLS download pipeline and still show a useful error.
- Use CMake's explicit source/build form and parallel target build for mbedcrypto.
- Remove the stale `patcher-bigendian` upload path; endianness is selected by `patcher` at runtime and no separate binary is built.
- Fail an upload when none of its configured artifact files are found instead of silently succeeding with an empty artifact.

## Verification ✅

Verified at commit 0c0ede5:

- [Build binaries](https://github.com/XxUnkn0wnxX/apollo-lib/actions/runs/33289192181): macOS and Ubuntu jobs passed.
- [Run tests](https://github.com/XxUnkn0wnxX/apollo-lib/actions/runs/33289192176): passed.
- The feature-branch push triggered both workflows, confirming that the triggers remain branch-unfiltered.
- The macOS job completed its Universal2 and deployment-target verification before uploading the CLI and GUI artifacts.

<details>
<summary>macOS checks performed before upload</summary>

`lipo -verify_arch x86_64 arm64` checks:

- `libmbedcrypto.a`
- `patcher`
- `dumper`
- `apollo_patcher_gui.app/Contents/MacOS/apollo_patcher_gui`
- `libapollo_engine.a`
- `libimgui.a`
- `libglfw3.a`

`otool` checks both the `x86_64` and `arm64` slices of:

- `patcher`
- `dumper`
- `apollo_patcher_gui`

Each executable slice must declare a minimum macOS version of `11.0`, otherwise the job fails before artifact upload.

</details>

## Scope

- Changes only `.github/workflows/build.yml`.
- Does not modify Apollo source code or its build-system files.
- Does not add Homebrew GUI dependencies.
